### PR TITLE
docs: correct link syntax

### DIFF
--- a/src/content/blog/creating-social-graph-images.mdx
+++ b/src/content/blog/creating-social-graph-images.mdx
@@ -217,7 +217,7 @@ This is the only part of the process that is typically not generated, of course 
 
 To keep our front-matter properly typed and take full advantage of Astro, we'll add the a field for the `HeroImage` in our collection schema, which will also allow us to enforce things such as a minimum image size.
 
-Luckily, Astro provides an [image helper for content collections(https://docs.astro.build/en/guides/images/#images-in-content-collections)].
+Luckily, Astro provides an [image helper for content collections](https://docs.astro.build/en/guides/images/#images-in-content-collections).
 
 ```ts title="src/content/config.ts"
 import { defineCollection, z } from "astro:content";


### PR DESCRIPTION
While reading the 'How I generate Open Graph images for my Astro-based blog', I fined this syntax error and fixed it.